### PR TITLE
Add user-select: none to disable copying

### DIFF
--- a/app/scripts/modal.js
+++ b/app/scripts/modal.js
@@ -103,7 +103,7 @@ function _addMarker(item) {
 	}
 	wrapperDiv = document.createElement('div');
 	wrapperDiv.id = 'chrome-envmarker';
-	wrapperDiv.setAttribute('style','text-shadow: -1px -1px 0 #555, 1px -1px 0 #555, -1px 1px 0 #555, 1px 1px 0 #555; position: fixed; '+positionStyle+' background-color: #'+item.color.replace('#','')+'; opacity: 0.9; z-index: 2147483647; height: 55px; width: 290px; overflow-x: hidden; box-shadow: 7px 0px 9px #000; color: #fff; pointer-events:none;');
+	wrapperDiv.setAttribute('style','text-shadow: -1px -1px 0 #555, 1px -1px 0 #555, -1px 1px 0 #555, 1px 1px 0 #555; position: fixed; '+positionStyle+' background-color: #'+item.color.replace('#','')+'; opacity: 0.9; z-index: 2147483647; height: 55px; width: 290px; overflow-x: hidden; box-shadow: 7px 0px 9px #000; color: #fff; pointer-events: none; user-select: none;');
 
 	textDiv = document.createElement('div');
 	textDiv.id = 'chrome-envmarker-text';


### PR DESCRIPTION
Currently when I copy the whole page's content (for example a .json file) the environment is also copied. So it's "{json}test" for the test environment. user-select: none prevents this